### PR TITLE
IMPROVE app checkout: custom SSL cert (Closes #54)

### DIFF
--- a/FabLabKasse/config.ini.example
+++ b/FabLabKasse/config.ini.example
@@ -30,11 +30,23 @@ enabled = true
 threshold_time = 1800
 
 [mobile_app]
+; load cart via smartphone app
 enabled = no
-server_url = http://ec2-52-28-173-123.eu-central-1.compute.amazonaws.com/checkout/ ;production
-;server_url = http://ec2-52-28-16-59.eu-central-1.compute.amazonaws.com/checkout/ ;development
+server_url = https://ec2-52-28-126-35.eu-central-1.compute.amazonaws.com:4433/checkout/ ; production new
 appstore_url = https://play.google.com/store/apps/details?id=de.fau.cs.mad.fablab.android
+
+; custom SSL certificate (if not trusted by the system CAs) in .crt file format, which can be exported from most webbrowsers
+; either use a path to a file (the path may not start with 'base64'):
+; ssl_cert = ./foo.crt
+; or use the base64 content of the file, prepended with 'base64://'
+; ssl_cert = base64://LS0tLS1CRUdJ...
+
+; production new:
+ssl_cert = base64://LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlEdlRDQ0FxV2dBd0lCQWdJRVptVC9HekFO QmdrcWhraUc5dzBCQVFzRkFEQ0JqakVMTUFrR0ExVUVCaE1DDQpSRVV4RHpBTkJnTlZCQWdUQmtK aGVXVnliakVSTUE4R0ExVUVCeE1JUlhKc1lXNW5aVzR4RERBS0JnTlZCQW9UDQpBMFpCVlRFUE1B MEdBMVVFQ3hNR1JtRmlUR0ZpTVR3d09nWURWUVFERXpObFl6SXROVEl0TWpndE1USTJMVE0xDQpM bVYxTFdObGJuUnlZV3d0TVM1amIyMXdkWFJsTG1GdFlYcHZibUYzY3k1amIyMHdIaGNOTVRVd09U QXhNVFV6DQpNek14V2hjTk1UWXdPRE14TVRVek16TXhXakNCampFTE1Ba0dBMVVFQmhNQ1JFVXhE ekFOQmdOVkJBZ1RCa0poDQplV1Z5YmpFUk1BOEdBMVVFQnhNSVJYSnNZVzVuWlc0eEREQUtCZ05W QkFvVEEwWkJWVEVQTUEwR0ExVUVDeE1HDQpSbUZpVEdGaU1Ud3dPZ1lEVlFRREV6TmxZekl0TlRJ dE1qZ3RNVEkyTFRNMUxtVjFMV05sYm5SeVlXd3RNUzVqDQpiMjF3ZFhSbExtRnRZWHB2Ym1GM2N5 NWpiMjB3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLDQpBb0lCQVFDTzNtc0dv RFJRNVhRcjhKMkx4UExWb1c1Vnh6UGF3YWVKUjhlOTk4cEVEZ0ZqRjNqbmZzUUlMdmRaDQo1Qi9H aXVQYTY4RGxOY3FwN2x5dmdFWGZHN3hMKzRYaGxoSVJKV3V3SFFJRWVoRGFhWU5FcXNWbTRCcUNU TWV1DQp6cW1wZ3E1Zmc4SU5ocHVqNTdwa2ljUzVUVS9QZ3ZxVnk0WnJUWE1wWlpkUzNsYkRlclpN UmxtVE5qZDFBQUpFDQorTFcxSE52OEZFdHFmTkRjWjJlbTRGYVZZTVA1dkl4S0I5S1MvR1luMzU2 bkZzZ3M5dDhKRUZhYWlLMmhmdkxZDQpnTXdlN2pqY0o5bUhxa0I5ZkZDdCtoQy9udGRNQi9SbE9y a0lYUHpMZ1FxeHZkRlBMazBjSElZZk9EZGgzak1IDQp4OThMMHVvVkxSeHUzYlZFcDBRUDRSdkZj aEJ6QWdNQkFBR2pJVEFmTUIwR0ExVWREZ1FXQkJUaG1xVzZPbEpQDQpUVlJSYUdRVmkzRTJzTjVr RWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVArcSs5QzBkQi9VNnFFZmxEWjhmDQpOQ2srMXN1 UENKcEhGSWUrNS96ZU1TcUN0MG5RRDY1QkRTOFQ3b2poMm5LUmNzQklZK2VxU1lKZDdPZG5ZUUNx DQpqdGFqNGNnckxVZ3lDQVg0aWxJSDBVR01rek1uUEU3ZzEyWlF1OGFLMFhSci9KUk54ZDd2QUZt SkNIRW9oUGhNDQptVTcxUDBBZTFzdEk2cWFYM2s0aUVJUUR4cHdYc3dCdS9CV25PWWlnejVyV0l0 SnRDT0JIYWdrbUpEdlBFZzdXDQpYdTR6RGF0QjFoNTFJQmpsZW4rUm5PNDZvc2Z2NU1ObXNoL3ZH cmV0L3g2QlZkYWoyb0RSRllmUkIxR3FHQy9sDQoyNzEweU81VUhHRzJqazVnNG1WbGdlaUg1ek13 b0FCVFVhbFk0VlRQeGRUbXJDcFNqUU1mZXZadWRtMFN1TStIDQpWQT09DQotLS0tLUVORCBDRVJU SUZJQ0FURS0tLS0tDQo=
+
+; custom timeout in seconds
 ;timeout = 10
+
 
 [receipt]
 header: FAU FabLab


### PR DESCRIPTION
noch gegen den AppServer zu testen, sobald die App wieder Warenkörbe hochladen kann
