### PR TITLE
Adapt code to new app api

### DIFF
--- a/FabLabKasse/config.ini.example
+++ b/FabLabKasse/config.ini.example
@@ -33,6 +33,7 @@ threshold_time = 1800
 ; load cart via smartphone app
 enabled = no
 server_url = https://ec2-52-28-126-35.eu-central-1.compute.amazonaws.com:4433/checkout/ ; production new
+server_api_key = dummyPassword
 appstore_url = https://play.google.com/store/apps/details?id=de.fau.cs.mad.fablab.android
 
 ; custom SSL certificate (if not trusted by the system CAs) in .crt file format, which can be exported from most webbrowsers


### PR DESCRIPTION
Adapt the app related code to the new api:
- The cart id is now generated from the app server and no longer from the terminal itself.
- Furthermore the api is now protected by a hardcoded ( :+1: ) passphrase.

Also the unittest is modified to run without a configfile.
