### PR TITLE
improve debugging

### DIFF
--- a/run.py
+++ b/run.py
@@ -84,14 +84,21 @@ def main():
             subprocess.call("./shopping/backend/legacy_offline_kassenbuch_tools/importProdukteOERP.py", env=myEnv)
 
     def check_winpdb_version():
-        """returns true on supported version of winpdb
+        """returns true if version of winpdb is larger than 1.4.8
+
+        uses the assumption that winpdb --version returns something like Winpdb 1.4.8 - Tychod
 
         :return: True, if winpdb-version is sufficient
         :rtype: Boolean
         """
-        # TODO implement version check
+        def versiontuple(v):
+            """simple tupel for comparing versions"""
+            return tuple(map(int, (v.split("."))))
+
         # call winpdb --version
-        return True
+        versionstring = subprocess.check_output("winpdb --version", shell=True)
+        version = versionstring.split(" ")[1]
+        return versiontuple(version) >= versiontuple("1.4.8")
 
     def runShutdown(program):
         "run sudo <program> and wait forever until the system reboots / shuts down"
@@ -115,7 +122,7 @@ def main():
     if debug:
         time.sleep(1)
         if not check_winpdb_version():
-            print("your version of winpdb is probably not supported")
+            print("WARNING: your version of winpdb is probably not supported")
             print("consider updating winpdb")
         debugger = subprocess.Popen(["winpdb", "-a", os.path.abspath("gui.py")], stdin=subprocess.PIPE)
         debugger.stdin.write("gui")

--- a/run.py
+++ b/run.py
@@ -83,6 +83,16 @@ def main():
         if cfg.get("backend", "backend") == "legacy_offline_kassenbuch":
             subprocess.call("./shopping/backend/legacy_offline_kassenbuch_tools/importProdukteOERP.py", env=myEnv)
 
+    def check_winpdb_version():
+        """returns true on supported version of winpdb
+
+        :return: True, if winpdb-version is sufficient
+        :rtype: Boolean
+        """
+        # TODO implement version check
+        # call winpdb --version
+        return True
+
     def runShutdown(program):
         "run sudo <program> and wait forever until the system reboots / shuts down"
         print("calling {}".format(program))
@@ -104,6 +114,9 @@ def main():
     gui = subprocess.Popen("python2.7 -m FabLabKasse.gui {}".format(debug).split(" "), env=myEnv)
     if debug:
         time.sleep(1)
+        if not check_winpdb_version():
+            print("your version of winpdb is probably not supported")
+            print("consider updating winpdb")
         debugger = subprocess.Popen(["winpdb", "-a", os.path.abspath("gui.py")], stdin=subprocess.PIPE)
         debugger.stdin.write("gui")
         debugger.stdin.close()

--- a/run.py
+++ b/run.py
@@ -101,10 +101,13 @@ def main():
     debug = ""
     if "--debug" in sys.argv:
         debug = "--debug"
-        fu = subprocess.Popen("winpdb -a gui.py".split(" "), stdin=subprocess.PIPE)
-        fu.stdin.write("gui")
-        fu.stdin.close()
-    subprocess.call("python2.7 -m FabLabKasse.gui {}".format(debug).split(" "), env=myEnv)
+    gui = subprocess.Popen("python2.7 -m FabLabKasse.gui {}".format(debug).split(" "), env=myEnv)
+    if debug:
+        time.sleep(1)
+        debugger = subprocess.Popen(["winpdb", "-a", os.path.abspath("gui.py")], stdin=subprocess.PIPE)
+        debugger.stdin.write("gui")
+        debugger.stdin.close()
+    gui.communicate()
     print("GUI exited")
     if "--debug" in sys.argv:
         sys.exit(0)


### PR DESCRIPTION
winpdb is not the best, but at least it attaches successfully now.

If run.py could just call `import gui; gui.main()`, one could just open run.py with any IDE and click debug, but this is not so easy because gui.py does some conditional imports and a workaround so that sphinx works.
