### PR TITLE
FIX import of multivariant prices

### DIFF
--- a/FabLabKasse/shopping/backend/legacy_offline_kassenbuch_tools/importProdukteOERP.py
+++ b/FabLabKasse/shopping/backend/legacy_offline_kassenbuch_tools/importProdukteOERP.py
@@ -54,7 +54,7 @@ def importProdukteOERP(data, oerp, cfg):
     print "OERP Import"
     prod_ids = oerp.search('product.product', [('default_code', '!=', False)])
     print "reading {} products from OERP, this may take some minutes...".format(len(prod_ids))
-    prods = oerp.read('product.product', prod_ids, ['code', 'name', 'uom_id', 'list_price', 'categ_id', 'active', 'sale_ok'],
+    prods = oerp.read('product.product', prod_ids, ['code', 'name', 'uom_id', 'lst_price', 'categ_id', 'active', 'sale_ok'],
                       context=oerp.context)
 
     # Only consider things with numerical PLUs in code field
@@ -64,7 +64,7 @@ def importProdukteOERP(data, oerp, cfg):
     integer_uoms = oerp.search('product.uom', [('rounding', '=', 1)])
 
     for p in prods:
-        if p['list_price'] <= 0:
+        if p['lst_price'] <= 0:
             # WORKAROUND: solange die Datenqualität so schlecht ist, werden Artikel mit Preis 0 erstmal ignoriert.
             continue
         if not p['active'] or not p['sale_ok']:
@@ -79,7 +79,7 @@ def importProdukteOERP(data, oerp, cfg):
         if p['uom_id'][0] in integer_uoms:
             p['input_mode'] = 'INTEGER'
         data[p['categ'][0]].append(
-            (p['code'], p['name'], p['uom_id'][1], p['list_price'], p['input_mode'], p['categ'][1:], []))
+            (p['code'], p['name'], p['uom_id'][1], p['lst_price'], p['input_mode'], p['categ'][1:], []))
 
     return data
 

--- a/FabLabKasse/shopping/backend/oerp.py
+++ b/FabLabKasse/shopping/backend/oerp.py
@@ -292,7 +292,7 @@ class ShoppingBackend(AbstractShoppingBackend):
         products = oerp.read(
             'product.product',
             product_ids,
-            ['name', 'property_stock_location', 'uos_id', 'uom_id', 'list_price'],
+            ['name', 'property_stock_location', 'uos_id', 'uom_id', 'lst_price'],
             context=oerp.context)
 
         # get pricelist
@@ -327,7 +327,7 @@ class ShoppingBackend(AbstractShoppingBackend):
                 # TODO only if product is in this category :(
                 location = category_default_location
             location = unicode(location)
-            data = Product(prod_id=p['id'], name=p['name'], price=float_to_decimal(p['list_price'], 3), unit=unit, location=location, categ_id=None)
+            data = Product(prod_id=p['id'], name=p['name'], price=float_to_decimal(p['lst_price'], 3), unit=unit, location=location, categ_id=None)
             products_preprocessed.append(data)
         return products_preprocessed
 


### PR DESCRIPTION
- oerp uses lst_price and list_price
- changed the code to use property lst_price
- lst_price and list_price are (without discounts effective) the same
- for multivariant articles the list_price isn't updated
- however lst_price stores the correct value
- fixes #78 

TODOs:
- [x] check if lst_price is ok (best case not me)
- [x] patch pricelist (does this need to be installed?)
- [x] patch etiketten
- [x] inform MAD-Team
- [x] reply to MAD-Team
- [x] install new version of etiketten

@fau-fablab/kasse please review.
