### PR TITLE
IMPROVE platform indepence by removing direct dependency to fcntl

### DIFF
--- a/FabLabKasse/scriptHelper.py
+++ b/FabLabKasse/scriptHelper.py
@@ -23,7 +23,7 @@ import signal
 import logging
 import logging.handlers
 import sys
-import fcntl
+import portalocker
 import sqlite3
 from ConfigParser import ConfigParser
 import codecs
@@ -108,12 +108,12 @@ class FileLock(object):
     """
     exclusive file-lock, for locking a resource against other processes
 
-    Only works on Linux (?)
+    Uses portalocker for platform-independence
     """
 
     def __init__(self, name):
         self.file = open(name + ".lock", "w")
         try:
-            fcntl.flock(self.file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            portalocker.lock(self.file, portalocker.LOCK_EX | portalocker.LOCK_NB)
         except IOError:
             raise Exception("lock " + name + " already taken, is another process already running?")

--- a/INSTALLING
+++ b/INSTALLING
@@ -24,6 +24,7 @@ If you have a standalone PC or VM only for FabLabKasse, you can also use `FabLab
         apt-get install python-pip python-qt4-dev python2.7 python-qt4 python-dateutil python-lxml pyqt4-dev-tools python-crypto python-termcolor python-serial python-natsort python-qrcode python-docopt python-requests python-simplejson python-sphinx
         pip install monotonic
         pip install oerplib # only for connection to OpenERP/odoo
+        pip install portalocker
 
  - for the real terminal implementation: xserver-xorg git nodm ssh x11-apps xterm
  - for the style: kde-style-oxygen kde-workspace-bin
@@ -57,9 +58,14 @@ Modem-Manager interferes with the serial port. It is highly recommended to remov
 
         dnf install python python-qt4 python-qt4-devel python-dateutil python-lxml python-crypto python-termcolor python-natsort python-qrcode python-docopt python-requests python-simplejson python-monotonic
         pip install oerplib # only for connection to OpenERP/odoo
+        pip install portalocker
 
  - for development: qt4-designer
  - for documentation: dnf: doxygen python-pygraphviz; pip: doxypy
+
+### 1d. Windows
+
+ TODO
 
 
 2.  Configuration

--- a/doc/FabLabKasse.libs.rst
+++ b/doc/FabLabKasse.libs.rst
@@ -10,8 +10,8 @@ Subpackages
 
     FabLabKasse.libs.escpos
     FabLabKasse.libs.flickcharm
-    FabLabKasse.libs.pxss
     FabLabKasse.libs.process_helper
+    FabLabKasse.libs.pxss
 
 Module contents
 ---------------

--- a/install_debian.sh
+++ b/install_debian.sh
@@ -13,6 +13,7 @@ sudo apt-get -y install python-pip python-qt4-dev python2.7 python-qt4 python-da
 sudo pip install natsort
 sudo pip install monotonic
 sudo pip install oerplib # only for connection to OpenERP/odoo
+sudo pip install portalocker
 sudo apt-get -y install xserver-xorg git nodm ssh x11-apps xterm kde-style-oxygen kde-workspace-bin fonts-crosextra-carlito
 
 # Setup user and 'kiosk mode' desktop manager that autostarts FabLabKasse


### PR DESCRIPTION
- use portalocker instead
- portalocker uses on posix-systems fcntl
- on nt it does win32api-calls
  @EmJay276 please test this on windows
