### PR TITLE
ADD codecoverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ addons:
 # load system_site_packages into virtualenv to make PyQt4 available
 virtualenv:
     system_site_packages: true
+before_install:
+    - pip install codecov
+after_success:
+    - codecov
 # command to run tests
 script:
     - cd FabLabKasse/UI/ && ./compile_all.py
-    - cd ../../ && python -m unittest discover -p '*.py' .
+    - cd ../../ && coverage run run_unittests.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FabLabKasse
 code climate: [![Code Climate](https://codeclimate.com/github/fau-fablab/FabLabKasse/badges/gpa.svg)](https://codeclimate.com/github/fau-fablab/FabLabKasse)
 [![Code Health](https://landscape.io/github/fau-fablab/FabLabKasse/development/landscape.svg?style=flat)](https://landscape.io/github/fau-fablab/FabLabKasse/development)
+[![Code Issues](https://www.quantifiedcode.com/api/v1/project/c80391d892bb409ab44b5fd0fd4573a4/badge.svg)](https://www.quantifiedcode.com/app/project/c80391d892bb409ab44b5fd0fd4573a4)
 
 unittests: [![Build Status](https://travis-ci.org/fau-fablab/FabLabKasse.svg?branch=development)](https://travis-ci.org/fau-fablab/FabLabKasse)
 [![codecov.io](https://codecov.io/github/fau-fablab/FabLabKasse/coverage.svg?branch=development)](https://codecov.io/github/fau-fablab/FabLabKasse?branch=development) (we are proudly untested [TM])

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ code climate: [![Code Climate](https://codeclimate.com/github/fau-fablab/FabLabK
 [![Code Health](https://landscape.io/github/fau-fablab/FabLabKasse/development/landscape.svg?style=flat)](https://landscape.io/github/fau-fablab/FabLabKasse/development)
 
 unittests: [![Build Status](https://travis-ci.org/fau-fablab/FabLabKasse.svg?branch=development)](https://travis-ci.org/fau-fablab/FabLabKasse)
+[![codecov.io](https://codecov.io/github/fau-fablab/FabLabKasse/coverage.svg?branch=development)](https://codecov.io/github/fau-fablab/FabLabKasse?branch=development) (we are proudly untested [TM])
 
 FabLabKasse, a Point-of-Sale Software for FabLabs and other public and trust-based workshops
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+# (C) 2015 Patrick Kanzler <patrick.kanzler@fablab.fau.de>
+
+# This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  The text of the license conditions can be read at
+#  <http://www.gnu.org/licenses/>.
+
+import sys
+import unittest
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().discover('.', '*.py')
+
+    testresult = unittest.TextTestRunner(verbosity=1).run(suite)
+    sys.exit(0 if testresult.wasSuccessful() else 1)

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # run all unittest cases in all .py files inside FabLabKasse
-python -m unittest discover -p '*.py' .
+python run_unittests.py


### PR DESCRIPTION
- uses codecov.io
- codecoverage is analyzed on travis-ci.org and then evaluated on codecov.io
- add testsuite that executes all tests
