### PR TITLE
IMPROVE MDB coin payout: soft-limit number of coins paid out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,9 @@
 # compiled files
 *.pyc
 
+# python-hypothesis
 .hypothesis/eval_source
+
+# python-coverage
+.coverage
+htmlcov

--- a/FabLabKasse/cashPayment/server/helpers/banknote_stack_helper.py
+++ b/FabLabKasse/cashPayment/server/helpers/banknote_stack_helper.py
@@ -21,9 +21,8 @@
 from __future__ import print_function
 import copy
 import random
-import math
 import unittest
-
+import FabLabKasse.libs.random_lists as random_lists
 
 class BanknoteStackHelper(object):
     """
@@ -189,7 +188,7 @@ class BanknoteStackHelperTester(BanknoteStackHelper):
         :param random.Random random_generator: RNG instance for calculating
             pseudorandom test parameters"""
         if payout_stack is None:
-            payout_stack = RandomLists.random_choice_list(
+            payout_stack = random_lists.random_choice_list(
                 random_generator,
                 possible_elements=[500, 1000, 2000, 5000],
                 number_of_elements=random.randint(1, 8))
@@ -266,29 +265,6 @@ class BanknoteStackHelperTester(BanknoteStackHelper):
         assert sum_paid_out <= requested_payout  # did not pay out too much
 
 
-class RandomLists(object):
-
-    """randomly built lists with randomness taken from random.choice()
-
-    .. WARNING:: not cryptographically secure!"""
-
-    @staticmethod
-    def random_integer_list(random_generator, integer_range, number_of_elements):
-        """ return a list of length number_of_elements
-        with elements in the range integer_range[0] <= element <= integer_range[1]"""
-        my_list = []
-        for _ in range(number_of_elements):
-            my_list.append(random_generator.randint(integer_range[0], integer_range[1]))
-        return my_list
-
-    @staticmethod
-    def random_choice_list(random_generator, possible_elements, number_of_elements):
-        """return a random list with len(list)==number_of_elements,
-        list[i] in possible_elements (duplicates are possible)"""
-        ret = []
-        for _ in range(number_of_elements):
-            ret.append(random_generator.choice(possible_elements))
-        return ret
 
 class BanknoteStackHelperTest(unittest.TestCase):
     """Tests the banknote stack helper class"""
@@ -326,7 +302,7 @@ class BanknoteStackHelperTest(unittest.TestCase):
         self.assertTrue(test1.can_payout([1001]) <= 999)
 
         # test random values and, especially hard, accepted_rest=999
-        for accepted_rest in RandomLists.random_integer_list(random_generator, [1, 123456], 42) + [999] * 10:
+        for accepted_rest in random_lists.random_integer_list(random_generator, (1, 123456), 42) + [999] * 10:
             test = BanknoteStackHelperTester(accepted_rest)
             for _ in xrange(2345):
                 test.unittest_payout(random_generator)

--- a/FabLabKasse/cashPayment/server/helpers/coin_payout_helper.py
+++ b/FabLabKasse/cashPayment/server/helpers/coin_payout_helper.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+# (C) 2015 Max Gaukler <development@maxgaukler.de>
+
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  The text of the license conditions can be read at
+#  <http://www.gnu.org/licenses/>.
+
+"""helper functions for multi-tube coin dispensers"""
+
+
+def get_possible_payout(coins, max_number_of_coins=15):
+    """
+    get possible amount of payout and remaining rest
+
+    This implementation returns a lower bound. This means that the theoretical
+    maximum possible amount can be higher (and will be often).
+
+    :type coins: list[(int, int)]
+    :param coins:
+        list of tuples ``(value, count)``, sorted descending by value.
+        The function still works if a value occurs twice (e.g. if you have a
+        dispenser with two separate tubes for 1€ coins).
+    :param int max_number_of_coins:
+        approximate upper limit for the number of coins -
+        this limits the reporting of the maximum possible amount of payout,
+        so that a device won't say it is able to pay out 50€,
+        if that is only possible with 500x 0,10€ coins.
+
+        Please note that if you limit this too much, the user will be warned
+        that there is not enough change money. Some amount is necessary,
+        especially in cooperation with other devices (e.g. banknotes + coins).
+    :return: as defined by :meth:`FabLabKasse.cashPayment.server.getCanPayout`
+    """
+    def is_sorted(iterable, reverse=False):
+        """
+        check if a list is sorted
+        :param list iterable: list of values
+        :param reverse: check for reverse sorted
+        :rtype: bool
+        """
+        return sorted(iterable, reverse=reverse) == iterable
+    assert is_sorted([value for (value, count) in coins], reverse=True), \
+        "Coins must be sorted descending by value"
+    total_amount = 0
+    previous_coin_value = None
+
+    # go through the coins from large to small
+    for (value, count) in coins:
+        assert isinstance(value, int)
+        assert isinstance(count, int)
+
+        if previous_coin_value is None:
+            # first run of the loop
+            previous_coin_value = 0
+        else:
+            if previous_coin_value % value != 0:
+                # the new coin value is not a proper fraction (e.g. 1/5) of the
+                # old coin value, so "splitting" (e.g. 50c -> 5x10c) is not
+                # possible
+                continue
+            if count * value < previous_coin_value:
+                # we dont have enough of this coin to "split" one previous coin
+                continue
+
+        # "split up" the previous coin, and add the remaining rest to to the
+        # possible total amount
+        total_amount += count * value - previous_coin_value
+        previous_coin_value = value
+
+    if previous_coin_value is None:
+        return [0, 0]
+
+    # limit total_amount to a practical maximum:
+    # starting with the highest coin value, pay out (simulated) as much as
+    # possible, until the maximum number of coins is reached.
+    # This is the maximum useful payout amount, because paying out more
+    # will require more coins.
+    coins_allowed_remaining = max_number_of_coins
+    maximum_useful_payout = 0
+    for (value, count) in coins:
+        if count > coins_allowed_remaining:
+            count = coins_allowed_remaining
+        coins_allowed_remaining -= count
+        maximum_useful_payout += count * value
+
+    if total_amount > maximum_useful_payout:
+        total_amount = maximum_useful_payout
+
+    return [total_amount, previous_coin_value]

--- a/FabLabKasse/cashPayment/server/helpers/test_coin_payout_helper.py
+++ b/FabLabKasse/cashPayment/server/helpers/test_coin_payout_helper.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+# (C) 2015 Max Gaukler <development@maxgaukler.de>
+
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  The text of the license conditions can be read at
+#  <http://www.gnu.org/licenses/>.
+
+"""tests for :mod:`coin_payout_helper`"""
+from __future__ import division
+import unittest
+import FabLabKasse.cashPayment.server.helpers.coin_payout_helper as coin_payout_helper
+from hypothesis import given, example, Settings, strategies as st
+from hypothesis.strategies import composite
+
+def simulate_payout(coins, requested):
+    """
+    get payout amount for a very simple simulated payout strategy
+    ('greedy strategy', just pay out largest coins first, without 'coin splitting' to get rid of smaller ones)
+
+    :type coins: list[(int, int)]
+    :param coins: see :meth:`coin_payout_helper.get_possible_payout`
+    :param int requested: requested amount
+    """
+    paid_out = 0
+    for (value, count) in coins:
+        # the // floor division operator from __future__ is used here for clarity
+        payout_count = min([count, (requested - paid_out) // value])
+        paid_out += payout_count * value
+    return paid_out
+
+@composite
+def st_coins(draw):
+    """ generator for random coin status """
+    st_usual_denominations = st.sets(st.sampled_from([200, 100, 50, 20, 10, 5, 2, 1]))
+    st_strange_denominations_and_duplicates = st.lists(st.integers(1, 200), average_size=8)
+    coin_values = draw(st.one_of(st_usual_denominations, st_strange_denominations_and_duplicates))
+    # sort descending by coin value, and convert to list
+    coin_values = sorted(coin_values, reverse=True)
+    coin_list = [(value, draw(st.integers(min_value=0, max_value=10))) for value in coin_values]
+    return coin_list
+
+class CoinPayoutHelperTestcase(unittest.TestCase):
+    """ Tests for :mod:`coin_payout_helper`"""
+    @given(st_coins(), st.floats(0, 1), st.floats(0, 1), settings=Settings(max_examples=1000))
+    # the following two fixed testcases are already enough for full code coverage
+    @example([], 1, .2)
+    @example([(100, 1), (50, 2), (20, 3), (10, 1), (5, 0), (2, 0), (1, 0)], 1, 0.01)
+    # another side-case: all zeroes
+    @example([(100, 0), (50, 0), (20, 0), (10, 0), (5, 0), (2, 0), (1, 0)], 1, .2)
+    def test_get_possible_payout(self, coins, requested_fraction, coin_limit_fraction):
+        """ test :meth:`coin_payout_helper.get_possible_payout()` for a given state of available coins"""
+        total = sum([value * count for (value, count) in coins])
+        num_coins = sum([count for (value, count) in coins])
+        (payout_infinite_coin_number, allowed_remaining) = coin_payout_helper.get_possible_payout(coins, max_number_of_coins=int(1e9))
+        # print coins, total, (payout_infinite_coin_number, allowed_remaining)
+        # the limit on the number of coins is not strictly guaranteed, so it isn't tested here.
+        (payout_limited_coin_number, _) = coin_payout_helper.get_possible_payout(coins, max_number_of_coins=round(coin_limit_fraction * (num_coins + 20)))
+
+        self.assertGreaterEqual(payout_limited_coin_number, 0)
+        self.assertGreaterEqual(payout_infinite_coin_number, 0)
+        self.assertLessEqual(payout_limited_coin_number, payout_infinite_coin_number)
+        self.assertLessEqual(payout_infinite_coin_number, total)
+        
+        # pick request, simulate payout
+        requested = round(requested_fraction * total)
+        paid_out = simulate_payout(coins, requested)
+        self.assertLessEqual(paid_out, requested)
+        if requested > payout_infinite_coin_number:
+            # requested too much, only the maximum is guaranteed
+            self.assertGreaterEqual(paid_out, payout_infinite_coin_number - allowed_remaining)
+        else:
+            self.assertGreaterEqual(paid_out, requested - allowed_remaining)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/FabLabKasse/libs/random_lists.py
+++ b/FabLabKasse/libs/random_lists.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+# (C) 2015 Max Gaukler <development@maxgaukler.de>
+
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  The text of the license conditions can be read at
+#  <http://www.gnu.org/licenses/>.
+
+"""randomly built lists with randomness taken from random.choice()
+
+.. WARNING:: not cryptographically secure!"""
+
+def random_integer_list(random_generator, integer_range, number_of_elements):
+    """ return a list of length number_of_elements
+    with elements in the range integer_range[0] <= element <= integer_range[1]
+    
+    :param random.Random random_generator: RNG instance
+    :param (int, int) integer_range: range (min, max) -- ends are included
+    :param int number_of_elements: length of resulting list"""
+    my_list = []
+    for _ in range(number_of_elements):
+        my_list.append(random_generator.randint(integer_range[0], integer_range[1]))
+    return my_list
+
+def random_choice_list(random_generator, possible_elements, number_of_elements):
+    """return a random list with len(list)==number_of_elements,
+    list[i] in possible_elements (duplicates are possible)
+    
+    :param random.Random random_generator: RNG instance 
+    :param list possible_elements: list elements to choose from
+    :param int number_of_elements: length of resulting list"""
+    ret = []
+    for _ in range(number_of_elements):
+        ret.append(random_generator.choice(possible_elements))
+    return ret

--- a/doc/FabLabKasse.cashPayment.server.helpers.rst
+++ b/doc/FabLabKasse.cashPayment.server.helpers.rst
@@ -12,6 +12,22 @@ FabLabKasse.cashPayment.server.helpers.banknote_stack_helper module
     :undoc-members:
     :show-inheritance:
 
+FabLabKasse.cashPayment.server.helpers.coin_payout_helper module
+----------------------------------------------------------------
+
+.. automodule:: FabLabKasse.cashPayment.server.helpers.coin_payout_helper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+FabLabKasse.cashPayment.server.helpers.test_coin_payout_helper module
+---------------------------------------------------------------------
+
+.. automodule:: FabLabKasse.cashPayment.server.helpers.test_coin_payout_helper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/doc/FabLabKasse.libs.rst
+++ b/doc/FabLabKasse.libs.rst
@@ -13,6 +13,18 @@ Subpackages
     FabLabKasse.libs.process_helper
     FabLabKasse.libs.pxss
 
+Submodules
+----------
+
+FabLabKasse.libs.random_lists module
+------------------------------------
+
+.. automodule:: FabLabKasse.libs.random_lists
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Module contents
 ---------------
 


### PR DESCRIPTION
- rewrite code and tests (using hypothesis library, which is quite useful here)
- add soft limit for number of coins (currently hardcoded to 15 coins)

Closes #42
