### PR TITLE
Argparse for kassenbuch.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.pyc
 
 # python-hypothesis
-.hypothesis
+.hypothesis/eval_source
 
 # python-coverage
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.pyc
 
 # python-hypothesis
-.hypothesis/eval_source
+.hypothesis
 
 # python-coverage
 .coverage

--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -794,7 +794,8 @@ def date_argcomplete(prefix, **kwargs):
 def argparse_parse_currency(amount):
     """parse currencies for argparse"""
     try:
-        amount = amount.replace(',', '.').replace('€', '').strip()
+        amount = amount.replace(',', '.').replace('€', '')
+        amount = amount.replace('EUR', '').strip()
         return Decimal(amount)
     except InvalidOperation as e:
         raise argparse.ArgumentTypeError(e.message)

--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -605,19 +605,22 @@ class Kunde(object):
         return summe
 
     def to_string(self, short=False):
-        summary = (u'Kunde {name} ({id}):\n    Schuldengrenze: {schuldengrenze:.2f} EUR\n    ' +
-                   u'Mail: {email}\n    Telefon: {telefon}\n    Adresse: {adresse}\n    ' +
-                   u'Kommentar: {kommentar}\n    PIN: {pin}').format(
+        summary = u"""Kunde: {name} (#{id}):
+    Schuldengrenze: {schuldengrenze:.2f} EUR
+    Mail:           {email}
+    Telefon:        {telefon}
+    Adresse:        {adresse}
+    Kommentar:      {kommentar}
+    PIN:            {pin}""".format(
             id=self.id, name=self.name, schuldengrenze=self.schuldengrenze,
             email=self.email, telefon=self.telefon, adresse=self.adresse,
             kommentar=self.kommentar, pin=self.pin)
 
-        details = Kundenbuchung.header
-        details += '\n'.join(map(lambda b: b.to_string(), self.buchungen))
-
         if short:
             return summary
         else:
+            details = Kundenbuchung.header
+            details += '\n'.join((b.to_string() for b in self.buchungen))
             return summary + '\n\n' + details
 
     def __repr__(self):

--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # PYTHON_ARGCOMPLETE_OK
 
-#
+
 # FabLabKasse, a Point-of-Sale Software for FabLabs and other public and
 # trust-based workshops.
 # Copyright (C) 2015  Julian Hammer <julian.hammer@fablab.fau.de>
@@ -45,7 +45,7 @@ import argparse
 try:
     import argcomplete
 except ImportError:
-    pass
+    pass  # NQA
 
 import doctest
 
@@ -755,7 +755,7 @@ def parse_date(value):
     """
     if isinstance(value, basestring) and value != '':
         value = value.lower().strip()
-        if value == 'now' or value == 'today':
+        if value in ['now', 'today']:
             return datetime.today()
         elif value == 'yesterday':
             return datetime.today() - timedelta(1)
@@ -808,12 +808,12 @@ def argparse_parse_client(value):
     try:
         return Kunde.load_from_id(int(value), k.cur)
     except (ValueError, NoDataFound):
-        pass
+        pass  # NQA
     try:
         return Kunde.load_from_name(value, k.cur)
     except NoDataFound:
         raise argparse.ArgumentTypeError(
-            u"Konnte keinen Kunde unter '%s' finden." % value)
+            u"Konnte keinen Kunde unter '{0}' finden.".format(value))
 
 
 def client_argcomplete(prefix, **kwargs):
@@ -833,7 +833,7 @@ def argparse_parse_receipt(rid):
         return Rechnung.load_from_id(int(rid), k.cur)
     except (ValueError, NoDataFound):
         raise argparse.ArgumentTypeError(
-            u"Konnte keine Rechnung mit der ID '%s' finden." % rid)
+            u"Konnte keine Rechnung mit der ID '{0}' finden.".format(rid))
 
 
 def receipt_argcomplete(prefix, **kwargs):

--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -45,7 +45,7 @@ import argparse
 try:
     import argcomplete
 except ImportError:
-    pass  # NQA
+    pass  # it's also working without argcomplete
 
 import doctest
 
@@ -808,7 +808,7 @@ def argparse_parse_client(value):
     try:
         return Kunde.load_from_id(int(value), k.cur)
     except (ValueError, NoDataFound):
-        pass  # NQA
+        pass  # ok, maybe it's not an ID but a name:
     try:
         return Kunde.load_from_name(value, k.cur)
     except NoDataFound:

--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -780,6 +780,17 @@ def argparse_parse_date(date):
         raise argparse.ArgumentTypeError(e.message)
 
 
+def date_argcomplete(prefix, **kwargs):
+    """tab completion for date"""
+    years = range(2010, datetime.today().year + 1)
+    months = range(1, 13)
+    days = range(1, 32)
+    lst = ["{y}-{m}-{d}".format(y=y, m=m, d=d) for y in years
+           for m in months for d in days]
+    lst += ['yesterday', 'today', 'now']
+    return [d for d in lst if d.startswith(prefix)]
+
+
 def argparse_parse_currency(amount):
     """parse currencies for argparse"""
     try:
@@ -861,7 +872,7 @@ def parse_args(argv=sys.argv[1:]):
         metavar='date',
         dest='from_date',
         help=DATE_HELP,
-    )
+    ).completer = date_argcomplete
     parser_show.add_argument(
         '--until',
         action='store',
@@ -869,7 +880,7 @@ def parse_args(argv=sys.argv[1:]):
         metavar='date',
         dest='until_date',
         help=DATE_HELP,
-    )
+    ).completer = date_argcomplete
     # export
     parser_export = subparsers.add_parser(
         'export',
@@ -895,7 +906,7 @@ def parse_args(argv=sys.argv[1:]):
         metavar='date',
         dest='from_date',
         help=DATE_HELP,
-    )
+    ).completer = date_argcomplete
     parser_export.add_argument(
         '--until',
         action='store',
@@ -903,14 +914,14 @@ def parse_args(argv=sys.argv[1:]):
         metavar='date',
         dest='until_date',
         help=DATE_HELP,
-    )
+    ).completer = date_argcomplete
     parser_export.add_argument(
         '--format',
         action='store',
         dest='format',
         metavar='fileformat',
         default='csv',
-        choices=['csv'],  # TODO more fileformats
+        choices=['csv'],
         help="format for the output file (default csv)",
     )
     # summary
@@ -925,7 +936,7 @@ def parse_args(argv=sys.argv[1:]):
         metavar='date',
         dest='until_date',
         help=DATE_HELP,
-    )
+    ).completer = date_argcomplete
     # transfer
     parser_transfer = subparsers.add_parser(
         'transfer',
@@ -934,13 +945,13 @@ def parse_args(argv=sys.argv[1:]):
     parser_transfer.add_argument(
         'source',
         action='store',
-        type=str,
+        type=str,  # TODO What is a valid source? -> provide tab completion
         help="the source",
     )
     parser_transfer.add_argument(
         'destination',
         action='store',
-        type=str,
+        type=str,  # TODO What is a valid dest? -> provide tab completion
         help="the destination",
     )
     parser_transfer.add_argument(

--- a/FabLabKasse/test_kassenbuch.py
+++ b/FabLabKasse/test_kassenbuch.py
@@ -19,9 +19,12 @@
 
 import unittest
 from FabLabKasse.kassenbuch import Kasse, Kunde, NoDataFound, parse_args
+from FabLabKasse.kassenbuch import argparse_parse_date, argparse_parse_currency
 from hypothesis import given
 from hypothesis.strategies import text
 import dateutil
+from datetime import datetime, timedelta
+from decimal import Decimal
 
 
 class KassenbuchTestCase(unittest.TestCase):
@@ -56,6 +59,17 @@ class KassenbuchTestCase(unittest.TestCase):
         self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31"))
         self.assertEquals(args.until_date, dateutil.parser.parse("2017-1-23"))
         # TODO more tests: Everytime you fix a bug in argparser, add a test
+
+    def test_parsing(self):
+        """test argument parsing helper"""
+        self.assertEqual(argparse_parse_currency(' 13,37€ '), Decimal('13.37'))
+        self.assertAlmostEqual(argparse_parse_date('today'), datetime.today(),
+                               delta=timedelta(minutes=5))
+        self.assertAlmostEqual(argparse_parse_date('yesterday'),
+                               datetime.today() - timedelta(1),
+                               delta=timedelta(minutes=5))
+        self.assertEqual(argparse_parse_date("2016-12-31 13:37:42"),
+                         dateutil.parser.parse("2016-12-31 13:37:42"))
 
     def test_accounting_database_setup(self):
         """tests the creation of the accounting database"""

--- a/FabLabKasse/test_kassenbuch.py
+++ b/FabLabKasse/test_kassenbuch.py
@@ -33,25 +33,25 @@ class KassenbuchTestCase(unittest.TestCase):
         """
         # test show
         args = parse_args("show".split(' '))
-        self.assertEqual(args.which, 'show')
+        self.assertEqual(args.action, 'show')
         self.assertFalse(args.hide_receipts)
         self.assertIsNone(args.from_date)
         self.assertIsNone(args.until_date)
         args = parse_args("show --hide-receipts".split(' '))
-        self.assertEqual(args.which, 'show')
+        self.assertEqual(args.action, 'show')
         self.assertTrue(args.hide_receipts)
         self.assertIsNone(args.from_date)
         self.assertIsNone(args.until_date)
         args = parse_args("show --hide-receipts "
                           "--from 2016-12-31 13:37:42".split(' '))
-        self.assertEqual(args.which, 'show')
+        self.assertEqual(args.action, 'show')
         self.assertTrue(args.hide_receipts)
         self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31 13:37:42"))
         self.assertIsNone(args.until_date)
         args = parse_args("show --hide-receipts "
                           "--from 2016-12-31 13:37:42"
                           "--until 2017-1-23".split(' '))
-        self.assertEqual(args.which, 'show')
+        self.assertEqual(args.action, 'show')
         self.assertTrue(args.hide_receipts)
         self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31 13:37:42"))
         self.assertEquals(args.until_date, dateutil.parser.parse("2017-1-23"))

--- a/FabLabKasse/test_kassenbuch.py
+++ b/FabLabKasse/test_kassenbuch.py
@@ -42,19 +42,20 @@ class KassenbuchTestCase(unittest.TestCase):
         self.assertTrue(args.hide_receipts)
         self.assertIsNone(args.from_date)
         self.assertIsNone(args.until_date)
-        args = parse_args("show --hide-receipts "
-                          "--from 2016-12-31 13:37:42".split(' '))
+        args = parse_args(['show', '--hide-receipts',
+                          '--from', '2016-12-31 13:37:42'])
         self.assertEqual(args.action, 'show')
         self.assertTrue(args.hide_receipts)
         self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31 13:37:42"))
         self.assertIsNone(args.until_date)
         args = parse_args("show --hide-receipts "
-                          "--from 2016-12-31 13:37:42"
+                          "--from 2016-12-31 "
                           "--until 2017-1-23".split(' '))
         self.assertEqual(args.action, 'show')
         self.assertTrue(args.hide_receipts)
-        self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31 13:37:42"))
+        self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31"))
         self.assertEquals(args.until_date, dateutil.parser.parse("2017-1-23"))
+        # TODO more tests: Everytime you fix a bug in argparser, add a test
 
     def test_accounting_database_setup(self):
         """tests the creation of the accounting database"""

--- a/FabLabKasse/test_kassenbuch.py
+++ b/FabLabKasse/test_kassenbuch.py
@@ -14,15 +14,48 @@
 #
 # You should have received a copy of the GNU General Public License along with this program. If not,
 # see <http://www.gnu.org/licenses/>.
+
 """unittests for kassenbuch.py"""
+
 import unittest
-from FabLabKasse.kassenbuch import Kasse, Kunde, NoDataFound
+from FabLabKasse.kassenbuch import Kasse, Kunde, NoDataFound, parse_args
 from hypothesis import given
 from hypothesis.strategies import text
+import dateutil
 
 
 class KassenbuchTestCase(unittest.TestCase):
     """unittests for kassenbuch.py"""
+
+    def test_argparse(self):
+        """
+        test the argparser
+        """
+        # test show
+        args = parse_args("show".split(' '))
+        self.assertEqual(args.which, 'show')
+        self.assertFalse(args.hide_receipts)
+        self.assertIsNone(args.from_date)
+        self.assertIsNone(args.until_date)
+        args = parse_args("show --hide-receipts".split(' '))
+        self.assertEqual(args.which, 'show')
+        self.assertTrue(args.hide_receipts)
+        self.assertIsNone(args.from_date)
+        self.assertIsNone(args.until_date)
+        args = parse_args("show --hide-receipts "
+                          "--from 2016-12-31 13:37:42".split(' '))
+        self.assertEqual(args.which, 'show')
+        self.assertTrue(args.hide_receipts)
+        self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31 13:37:42"))
+        self.assertIsNone(args.until_date)
+        args = parse_args("show --hide-receipts "
+                          "--from 2016-12-31 13:37:42"
+                          "--until 2017-1-23".split(' '))
+        self.assertEqual(args.which, 'show')
+        self.assertTrue(args.hide_receipts)
+        self.assertEquals(args.from_date, dateutil.parser.parse("2016-12-31 13:37:42"))
+        self.assertEquals(args.until_date, dateutil.parser.parse("2017-1-23"))
+
     def test_accounting_database_setup(self):
         """tests the creation of the accounting database"""
         kasse = Kasse(sqlite_file=':memory:')

--- a/INSTALLING
+++ b/INSTALLING
@@ -23,8 +23,9 @@ If you have a standalone PC or VM only for FabLabKasse, you can also use `FabLab
 
         apt-get install python-pip python-qt4-dev python2.7 python-qt4 python-dateutil python-lxml pyqt4-dev-tools python-crypto python-termcolor python-serial python-natsort python-qrcode python-docopt python-requests python-simplejson python-sphinx
         pip install monotonic
-        pip install oerplib # only for connection to OpenERP/odoo
+        pip install oerplib  # only for connection to OpenERP/odoo
         pip install portalocker
+        pip install argparse argcomplete  # for kassenbuch.py
 
  - for the real terminal implementation: xserver-xorg git nodm ssh x11-apps xterm
  - for the style: kde-style-oxygen kde-workspace-bin
@@ -59,6 +60,7 @@ Modem-Manager interferes with the serial port. It is highly recommended to remov
         dnf install python python-qt4 python-qt4-devel python-dateutil python-lxml python-crypto python-termcolor python-natsort python-qrcode python-docopt python-requests python-simplejson python-monotonic
         pip install oerplib # only for connection to OpenERP/odoo
         pip install portalocker
+        pip install argparse argcomplete  # for kassenbuch.py
 
  - for development: qt4-designer
  - for documentation: dnf: doxygen python-pygraphviz; pip: doxypy
@@ -124,6 +126,7 @@ recommended setup firewall:
 
 TODO....
 
-GUI for normal users
-administrative tasks: `ssh kasse@terminal; cd FabLabKasse; ./kassenbuch.py`
--> see help output
+ - GUI for normal users
+ - administrative tasks: `ssh kasse@terminal; cd FabLabKasse; ./kassenbuch.py -h`
+    - see help output
+    - run `activate-global-python-argcomplete` to enable tab completion

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,13 @@ natsort
 monotonic
 oerplib
 portalocker
+
 # dependency of escpos
 Pillow
-#testing
+
+# testing
 hypothesis<=1.19.0
+
+# clis (kassenbuch.py)
+argparse
+argcomplete


### PR DESCRIPTION
- See #76 (but using argcomplete insteat of docopt tab completion)
- Makes #103 easily solveable :tm: 
- May help for #106 as argparse parses the args in utf8(?)
- Introduces tab completion in `kassenbuch.py`
- One could use this in `cash`, too (see #104 )
- Needs testing, but I found no bugs :tm: 
- Some other code improvements :tm: 

Sorry, this is much code but it is very, very mighty :)

_Remember to run [`activate-global-python-argcomplete`](https://pypi.python.org/pypi/argcomplete) to enable tab completion. (also for deploying on kassenterminal)_
