### PR TITLE
Ich brauche keine Rechnung -> Quittung

### DIFF
--- a/FabLabKasse/UI/PayupCashDialogCode.py
+++ b/FabLabKasse/UI/PayupCashDialogCode.py
@@ -289,7 +289,7 @@ class PayupCashDialog(QtGui.QDialog, Ui_PayupCashDialog):
             # and we are not in the special case where receipt printing is enforced by the backend
             if self.centsReceived > self.centsPaidOut and self.centsToPay > 0:
                 self.pushButton_receipt.setVisible(True)
-                self.pushButton_finish.setText(u"Ich brauche keine Rechnung")
+                self.pushButton_finish.setText(u"Ich brauche keine Quittung")
         else:
             raise Exception("Unknown state")
 


### PR DESCRIPTION
See #117, #118

Kevin hat noch ein "Rechnung" entdeckt ;)

Mag man eig. allgemein mal `sed -i 's/Rechung/Quittung/g` über das ganze Projekt laufen lassen? Oder geht das zu weit?
