### PR TITLE
WIP: Fix kassenbuch get_buchungen for microseconds

### DIFF
--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -365,6 +365,8 @@ class Kasse(object):
         :type until_date: datetime.datetime | None
         :return: query string
         """
+        assert isinstance(from_date, (datetime, type(None)))
+        assert isinstance(until_date, (datetime, type(None)))
         # TODO comparing against these strings might make problems with py3
         # --> best import unicode_literals from future
         # --> check whole file if this import is problematic
@@ -374,15 +376,15 @@ class Kasse(object):
 
         query = "SELECT id FROM {0}".format(from_table)
         if from_date and until_date:
-            query = query + " WHERE datum >= Datetime('{from_date}') AND datum < Datetime('{until_date}')".format(
+            query = query + " WHERE Datetime(datum) >= Datetime('{from_date}') AND Datetime(datum) < Datetime('{until_date}')".format(
                 from_date=from_date, until_date=until_date
             )
         elif from_date:
-            query = query + " WHERE datum >= Datetime('{from_date}')".format(
+            query = query + " WHERE Datetime(datum) >= Datetime('{from_date}')".format(
                 from_date=from_date
             )
         elif until_date:
-            query = query + " WHERE datum < Datetime('{until_date}')".format(
+            query = query + " WHERE Datetime(datum) < Datetime('{until_date}')".format(
                 until_date=until_date
             )
 
@@ -395,6 +397,8 @@ class Kasse(object):
     def get_buchungen(self, from_date=None, until_date=None):
         """
         get accounting records between the given dates. If a date is ``None``, no filter will be applied.
+
+        The time comparison will ignore the fractional second part.
 
         :param from_date: start datetime (included)
         :param until_date: end datetime (not included)
@@ -417,6 +421,8 @@ class Kasse(object):
     def get_rechnungen(self, from_date=None, until_date=None):
         """
         get invoices between the given dates. If a date is ``None``, no filter will be applied.
+
+        The time comparison will ignore the fractional second part.
 
         :param from_date: start datetime (included)
         :param until_date: end datetime (not included)

--- a/FabLabKasse/kassenbuch.py
+++ b/FabLabKasse/kassenbuch.py
@@ -116,8 +116,9 @@ class NoDataFound(Exception):
 class Rechnung(object):
 
     def __init__(self, id=None, datum=None):
+        assert(isinstance(id, (int, type(None))))
+        assert(isinstance(datum, (datetime, type(None))))
         self.id = id
-
         if not datum:
             self.datum = datetime.now()
         else:
@@ -248,6 +249,8 @@ class Rechnung(object):
 class Buchung(object):
 
     def __init__(self, konto, betrag, rechnung=None, kommentar=None, id=None, datum=None):
+        assert(isinstance(id, (int, type(None))))
+        assert(isinstance(datum, (datetime, type(None))))
         self.id = id
         if not datum:
             self.datum = datetime.now()

--- a/FabLabKasse/test_kassenbuch.py
+++ b/FabLabKasse/test_kassenbuch.py
@@ -101,14 +101,14 @@ class KassenbuchTestCase(unittest.TestCase):
     def test_datestring_generator(self, from_date, until_date):
         """test the datestring_generator in Kasse"""
         query = Kasse._date_query_generator('buchung', from_date=from_date, until_date=until_date)
-        pristine_query = "SELECT id FROM buchung WHERE datum >= Datetime('{from_date}') AND " \
-                         "datum < Datetime('{until_date}')".format(from_date=from_date, until_date=until_date)
+        pristine_query = "SELECT id FROM buchung WHERE Datetime(datum) >= Datetime('{from_date}') AND " \
+                         "Datetime(datum) < Datetime('{until_date}')".format(from_date=from_date, until_date=until_date)
         self.assertEqual(query, pristine_query)
         query = Kasse._date_query_generator('buchung', until_date=until_date)
-        pristine_query = "SELECT id FROM buchung WHERE datum < Datetime('{until_date}')".format(until_date=until_date)
+        pristine_query = "SELECT id FROM buchung WHERE Datetime(datum) < Datetime('{until_date}')".format(until_date=until_date)
         self.assertEqual(query, pristine_query)
         query = Kasse._date_query_generator('buchung', from_date=from_date)
-        pristine_query = "SELECT id FROM buchung WHERE datum >= Datetime('{from_date}')".format(from_date=from_date)
+        pristine_query = "SELECT id FROM buchung WHERE Datetime(datum) >= Datetime('{from_date}')".format(from_date=from_date)
         self.assertEqual(query, pristine_query)
 
     @given(rechnung_date=hypothesis_datetime.datetimes(min_year=1900, timezones=[]),
@@ -122,6 +122,10 @@ class KassenbuchTestCase(unittest.TestCase):
         kasse.con.commit()
 
         query = kasse.get_rechnungen(from_date, until_date)
+        # the time comparison does not care about fractions of a second
+        from_date = from_date.replace(microsecond=0)
+        until_date = until_date.replace(microsecond=0)
+        rechnung_date = rechnung_date.replace(microsecond=0)
         if from_date <= rechnung_date < until_date:
             self.assertTrue(query)
         else:
@@ -147,6 +151,10 @@ class KassenbuchTestCase(unittest.TestCase):
 
         #TODO load_from_row ist sehr anfällig gegen kaputte datetimes, das sollte am besten schon sauber in die Datenbank
         query = kasse.get_buchungen(from_date, until_date)
+        # the time comparison does not care about fractions of a second
+        from_date = from_date.replace(microsecond=0)
+        until_date = until_date.replace(microsecond=0)
+        buchung_date = buchung_date.replace(microsecond=0)
         if from_date <= buchung_date < until_date:
             self.assertTrue(query)
         else:


### PR DESCRIPTION
Using `Datetime()` in the SQLite query strips away the microseconds. SQLites cannot do datetime formatting for microseconds, even with `strftime()`.

First workaround:
Discards all microseconds when filtering for a specific time range.

Problem:
This may create a race-condition if a booking is made at xxx.100 seconds and then `kassenbuch show` is called at xxx.200 sec, because the booking was made after xxx.000 sec
and the `snapshot_time` mechanism filters out the booking from the "future".
