### PR TITLE
Python2 archaeology

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:18.04
+ADD install_debian.sh /
+ENV DOCKER=1
+RUN mkdir /FabLabKasse_setup/
+ADD requirements.txt /FabLabKasse_setup/
+ADD install_debian.sh /FabLabKasse_setup/
+WORKDIR /FabLabKasse_setup
+RUN yes | ./install_debian.sh
+CMD xeyes

--- a/FabLabKasse/faucardPayment/FAUcardPaymentThread.py
+++ b/FabLabKasse/faucardPayment/FAUcardPaymentThread.py
@@ -17,6 +17,7 @@ from ..shopping.backend.abstract import float_to_decimal
 try:                    # Test if interface is available
     from magpos import magpos, codes
 except ImportError as e:     # Load Dummy otherwise
+    logging.warning("failed to import 'magpos' plugin class, falling back to dummy interface: " + repr(e))
     print e
     from dinterface import magpos, codes
 

--- a/FabLabKasse/gui.py
+++ b/FabLabKasse/gui.py
@@ -730,6 +730,7 @@ class Kassenterminal(Ui_Kassenterminal, QtGui.QMainWindow):
 
     def buttonDelete(self):
         order_line = self.getSelectedOrderLineId()
+        logging.debug("buttonDelete " + str(order_line))
         if order_line is not None:
             self.shoppingBackend.delete_order_line(order_line)
             self.updateOrder()

--- a/install_debian.sh
+++ b/install_debian.sh
@@ -18,6 +18,11 @@ if [ ! -f requirements.txt ]; then
     exit 1
 fi
 
+# Try to install sudo, ignore errors if we are not root
+apt-get update || true
+apt-get -qy install sudo || true
+
+
 # Install dependencies
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y install git
@@ -53,8 +58,10 @@ else
 fi
 
 # the OpenERP import requires a german locale -- add it.
+sudo apt-get -qy install locales # some containers don't have the locale package preinstalled
 echo 'de_DE.UTF-8 UTF-8' | sudo tee -a /etc/locale.gen
 # cd /usr/share/locales && sudo ./install-language-pack de_DE
+
 sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales
 
 # allow shutdown/reboot for any user

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ sphinx_rtd_theme
 
 #faucardpayment
 enum34==1.1.6
+future

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# Run GUI in docker, forwarding X11 (for GUI) and /dev/pts/* (for fake serial port for FAUCard emulator).
+# This does not provide any kind of security separation. Docker only helps to provide the old libraries on a modern host system.
+docker build . -t fablab.fau.de/fablabkasse
+docker run -e DISPLAY --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -v $(pwd):/home/FabLabKasse/FabLabKasse -v /dev/pts:/dev/pts --user="$(id --user):$(id --group)" fablab.fau.de/fablabkasse /home/FabLabKasse/FabLabKasse/run.py


### PR DESCRIPTION
Some hacks to simplify testing the old version with Py2. Most of this will never be merged because it becomes obsolete by the Py3 migration.